### PR TITLE
feat: add a configurable per-request HTTP timeout

### DIFF
--- a/src/ecactus/base.py
+++ b/src/ecactus/base.py
@@ -29,6 +29,7 @@ class _BaseEcos:
         url: str | None = None,
         access_token: str | None = None,
         refresh_token: str | None = None,
+        timeout: float | None = 30.0,
     ) -> None:
         """Initialize a session with ECOS API.
 
@@ -41,6 +42,8 @@ class _BaseEcos:
             url: The URL of the ECOS API. If specified, `datacenter` is ignored.
             access_token: The access token for authentication with the ECOS API.
             refresh_token: The refresh token for authentication with the ECOS API.
+            timeout: Per-request timeout in seconds (total). Applied to every HTTP
+                call. `None` disables the timeout. Defaults to 30 seconds.
 
         Raises:
             InitializationError: If `datacenter` is not one of `CN`, `EU`, or `AU` and `url` is not provided.
@@ -52,6 +55,7 @@ class _BaseEcos:
         self.country = country
         self.access_token = access_token
         self.refresh_token = refresh_token
+        self.timeout = timeout
         # TODO: get datacenters from https://dcdn-config.weiheng-tech.com/prod/config.json
         datacenters = {
             "CN": "https://api-ecos-hu.weiheng-tech.com",
@@ -94,7 +98,10 @@ class _BaseEcos:
         response = None
         try:
             response = requests.get(
-                full_url, params=payload, headers={"Authorization": self.access_token}
+                full_url,
+                params=payload,
+                headers={"Authorization": self.access_token},
+                timeout=self.timeout,
             )
             logger.debug(response.text)
             body = response.json()
@@ -142,7 +149,10 @@ class _BaseEcos:
         response = None
         try:
             response = requests.post(
-                full_url, json=payload, headers={"Authorization": self.access_token}
+                full_url,
+                json=payload,
+                headers={"Authorization": self.access_token},
+                timeout=self.timeout,
             )
             logger.debug(response.text)
             body = response.json()
@@ -193,7 +203,8 @@ class _BaseEcos:
             if self.access_token is not None
             else None
         )
-        async with aiohttp.ClientSession() as session:
+        timeout = aiohttp.ClientTimeout(total=self.timeout)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
             response = None
             try:
                 async with session.get(
@@ -248,7 +259,8 @@ class _BaseEcos:
             if self.access_token is not None
             else None
         )
-        async with aiohttp.ClientSession() as session:
+        timeout = aiohttp.ClientTimeout(total=self.timeout)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
             response = None
             try:
                 async with session.post(

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -556,6 +556,11 @@ class EcosMockServer:
             }
         )
 
+    async def handle_slow(self, request: web.Request) -> web.Response:
+        """Endpoint that delays before responding (used to test request timeouts)."""
+        await asyncio.sleep(1.0)
+        return self._success_response({"slept": True})
+
     async def catch_all(self, request: web.Request) -> web.Response:
         """Catch all endpoint."""
         # if request.path starts with /api/client/ then
@@ -610,6 +615,7 @@ class EcosMockServer:
                     "/api/client/home/events/fault",
                     self.handle_get_fault_events,
                 ),
+                web.get("/slow", self.handle_slow),
                 web.route("*", "/+{path:.*}", self.catch_all),
             ]
         )

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,38 @@
+"""Unit tests for the shared HTTP base (timeout handling)."""
+
+import pytest
+import requests
+
+import ecactus
+
+
+def test_default_timeout():
+    """A default per-request timeout is configured."""
+    client = ecactus.AsyncEcos(url="http://example.invalid")
+    assert client.timeout == 30.0
+
+
+def test_custom_timeout_is_stored():
+    """A caller-provided timeout overrides the default."""
+    client = ecactus.AsyncEcos(url="http://example.invalid", timeout=5)
+    assert client.timeout == 5
+
+
+def test_timeout_can_be_disabled():
+    """timeout=None disables the timeout (previous behaviour)."""
+    client = ecactus.AsyncEcos(url="http://example.invalid", timeout=None)
+    assert client.timeout is None
+
+
+async def test_async_request_times_out(mock_server):
+    """An aiohttp call exceeding the timeout raises instead of hanging."""
+    client = ecactus.AsyncEcos(url=mock_server.url, timeout=0.1)
+    with pytest.raises(TimeoutError):
+        await client._async_get("/slow")  # noqa: SLF001
+
+
+def test_sync_request_times_out(mock_server):
+    """A requests call exceeding the timeout raises instead of hanging."""
+    client = ecactus.Ecos(url=mock_server.url, timeout=0.1)
+    with pytest.raises(requests.exceptions.Timeout):
+        client._get("/slow")  # noqa: SLF001


### PR DESCRIPTION
## Problem

Neither the `requests` (sync) nor the `aiohttp` (async) calls set a request timeout. A stalled connection to the ECOS API therefore hangs:

- **sync path:** indefinitely (no timeout at all),
- **async path:** up to aiohttp's ~5-minute default.

For a long-running poller a single stuck call can wedge the whole loop.

## Change

Add a `timeout` parameter to the client (default **30 s**, total per request), stored on `_BaseEcos` and applied to every HTTP call:

- `requests` via `timeout=self.timeout`,
- `aiohttp` via `ClientTimeout(total=self.timeout)`.

Passing `timeout=None` keeps the previous unbounded behaviour, so this is fully backward-compatible.

## Tests

- Adds a `/slow` route to the mock server (sleeps before responding).
- New `tests/test_base.py` covering the default / custom / `None` settings and an actual timeout being raised on **both** transports.

`pytest`, `ruff` and `scripts/unasync.py --check` all pass; no new `mypy` findings.
