### PR TITLE
fix: build the Authorization header consistently (resolves mypy under newer requests)

### DIFF
--- a/src/ecactus/base.py
+++ b/src/ecactus/base.py
@@ -91,11 +91,14 @@ class _BaseEcos:
         api_path = api_path.lstrip("/")  # remove / from beginning of api_path
         full_url = self.url + "/" + api_path
         logger.debug("API GET call: %s", full_url)
+        headers = (
+            {"Authorization": self.access_token}
+            if self.access_token is not None
+            else None
+        )
         response = None
         try:
-            response = requests.get(
-                full_url, params=payload, headers={"Authorization": self.access_token}
-            )
+            response = requests.get(full_url, params=payload, headers=headers)
             logger.debug(response.text)
             body = response.json()
         except requests.exceptions.JSONDecodeError as err:
@@ -139,11 +142,14 @@ class _BaseEcos:
         api_path = api_path.lstrip("/")  # remove / from beginning of api_path
         full_url = self.url + "/" + api_path
         logger.debug("API POST call: %s", full_url)
+        headers = (
+            {"Authorization": self.access_token}
+            if self.access_token is not None
+            else None
+        )
         response = None
         try:
-            response = requests.post(
-                full_url, json=payload, headers={"Authorization": self.access_token}
-            )
+            response = requests.post(full_url, json=payload, headers=headers)
             logger.debug(response.text)
             body = response.json()
         except requests.exceptions.JSONDecodeError as err:


### PR DESCRIPTION
## Problem

`mypy` currently fails on `main` (released 0.3.0), independently of any change:

```
src/ecactus/base.py: error: Dict entry 0 has incompatible type "str": "str | None";
expected "str": "str | bytes"  [dict-item]   (x2)
```

The synchronous `_get`/`_post` pass `headers={"Authorization": self.access_token}` inline, where `access_token` is `str | None`. Newer `requests` releases ship stricter type hints (header values must be `str | bytes`), so type-checking the released code now errors on these two calls. Since the CI `mypy` step runs against the latest `requests`, the check is red on `main`.

## Change

Build the header dict conditionally and fall back to no headers when there is no token — mirroring what the async `_async_get`/`_async_post` already do:

```python
headers = (
    {"Authorization": self.access_token}
    if self.access_token is not None
    else None
)
```

This restores a clean `mypy` run and makes the sync and async paths behave identically (neither sends an `Authorization` header before login).

## No behaviour change

`requests` already omits a header whose value is `None`, so the login call (made before a token exists) behaves exactly as before.

## Verification

In a clean `.[dev]` environment (matching CI): `ruff check`, `mypy`, `pytest` and `scripts/unasync.py --check` all pass.
