### PR TITLE
fix: evaluate metric timestamp defaults per instance

### DIFF
--- a/src/ecactus/model.py
+++ b/src/ecactus/model.py
@@ -160,7 +160,7 @@ class PowerMetrics(BaseModel):
 
     """
 
-    timestamp: datetime = Field(default=datetime.now())
+    timestamp: datetime = Field(default_factory=datetime.now)
     solar: Annotated[float | None, Field(strict=True, ge=0, alias="solarPower")]
     grid: float | None = Field(alias="gridPower")
     battery: float | None = Field(alias="batteryPower")
@@ -471,7 +471,7 @@ class ConsumptionMetrics(BaseModel):
 
     """
 
-    timestamp: datetime = Field(default=datetime.now())
+    timestamp: datetime = Field(default_factory=datetime.now)
     from_battery: Annotated[float | None, Field(strict=True, ge=0, alias="fromBatteryDps")]
     to_battery: Annotated[float | None, Field(strict=True, ge=0, alias="toBatteryDps")]
     from_grid: Annotated[float | None, Field(strict=True, ge=0, alias="fromGridDps")]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,40 @@
+"""Unit tests for the data models."""
+
+from datetime import datetime
+
+from ecactus.model import ConsumptionMetrics, PowerMetrics
+
+
+def test_power_metrics_timestamp_uses_default_factory():
+    """The default timestamp must be evaluated per instance, not once at import.
+
+    With ``Field(default=datetime.now())`` the default is frozen at class
+    definition time, so every instance shares the import-time timestamp. A
+    ``default_factory`` evaluates ``datetime.now`` at instantiation instead.
+    """
+    before = datetime.now()
+    metric = PowerMetrics(
+        solarPower=0,
+        gridPower=0,
+        batteryPower=0,
+        meterPower=0,
+        homePower=0,
+        epsPower=0,
+    )
+    assert metric.timestamp >= before
+
+
+def test_consumption_metrics_timestamp_uses_default_factory():
+    """Same default_factory guarantee for ConsumptionMetrics."""
+    before = datetime.now()
+    metric = ConsumptionMetrics(
+        fromBatteryDps=0,
+        toBatteryDps=0,
+        fromGridDps=0,
+        toGridDps=0,
+        fromSolarDps=0,
+        homeEnergyDps=0,
+        epsDps=0,
+        selfPoweredDps=0,
+    )
+    assert metric.timestamp >= before


### PR DESCRIPTION
## Problem

`PowerMetrics.timestamp` and `ConsumptionMetrics.timestamp` use `Field(default=datetime.now())`. The default expression is evaluated **once, at class-definition (import) time**, so every instance created without an explicit timestamp shares that single import-time value rather than reflecting when it was actually built.

## Change

Switch both fields to `Field(default_factory=datetime.now)`, so the default is evaluated per instance at construction time.

## Tests

Adds `tests/test_model.py` asserting the timestamp is `>= a time captured just before instantiation` for both models — which fails with the frozen default and passes with the factory.

Verified in a clean `.[dev]` environment (matching CI): `ruff`, `mypy`, `pytest` and `scripts/unasync.py --check` all pass.
