### PR TITLE
fix: raise a library error instead of KeyError on malformed responses

### DIFF
--- a/src/ecactus/base.py
+++ b/src/ecactus/base.py
@@ -116,15 +116,15 @@ class _BaseEcos:
                 error_msg = body.get(
                     "message", response.text
                 )  # return message from JSON if avalaible, or HTTP response text
-                if body["code"] == 401:
+                if body.get("code") == 401:
                     raise UnauthorizedError(error_msg)
-                if body["code"] is not None:
-                    raise ApiResponseError(body["code"], error_msg)
+                if body.get("code") is not None:
+                    raise ApiResponseError(body.get("code"), error_msg)
                 raise HttpError(response.status_code, error_msg)
-            if not body["success"]:
+            if not body.get("success"):
                 logger.debug(body)
-                raise ApiResponseError(body["code"], body["message"])
-        return body["data"]
+                raise ApiResponseError(body.get("code"), body.get("message"))
+        return body.get("data")
 
     def _post(self, api_path: str, payload: JSON = {}) -> JSON:
         """Make a POST request to the ECOS API.
@@ -169,15 +169,15 @@ class _BaseEcos:
                 error_msg = body.get(
                     "message", response.text
                 )  # return message from JSON if avalaible, or HTTP response text
-                if body["code"] == 401:
+                if body.get("code") == 401:
                     raise UnauthorizedError(error_msg)
-                if body["code"] is not None:
-                    raise ApiResponseError(body["code"], error_msg)
+                if body.get("code") is not None:
+                    raise ApiResponseError(body.get("code"), error_msg)
                 raise HttpError(response.status_code, error_msg)
-            if not body["success"]:
+            if not body.get("success"):
                 logger.debug(body)
-                raise ApiResponseError(body["code"], body["message"])
-        return body["data"]
+                raise ApiResponseError(body.get("code"), body.get("message"))
+        return body.get("data")
 
     async def _async_get(self, api_path: str, payload: dict[str, Any] = {}) -> JSON:
         """Make a GET request to the ECOS API.
@@ -225,15 +225,15 @@ class _BaseEcos:
                     error_msg = body.get(
                         "message", await response.text()
                     )  # return message from JSON if avalaible, or HTTP response text
-                    if body["code"] == 401:
+                    if body.get("code") == 401:
                         raise UnauthorizedError(error_msg)
-                    if body["code"] is not None:
-                        raise ApiResponseError(body["code"], error_msg)
+                    if body.get("code") is not None:
+                        raise ApiResponseError(body.get("code"), error_msg)
                     raise HttpError(response.status, error_msg)
-                if not body["success"]:
+                if not body.get("success"):
                     logger.debug(body)
-                    raise ApiResponseError(body["code"], body["message"])
-        return body["data"]
+                    raise ApiResponseError(body.get("code"), body.get("message"))
+        return body.get("data")
 
     async def _async_post(self, api_path: str, payload: JSON = {}) -> JSON:
         """Make a POST request to the ECOS API.
@@ -281,12 +281,12 @@ class _BaseEcos:
                     error_msg = body.get(
                         "message", await response.text()
                     )  # return message from JSON if avalaible, or HTTP response text
-                    if body["code"] == 401:
+                    if body.get("code") == 401:
                         raise UnauthorizedError(error_msg)
-                    if body["code"] is not None:
-                        raise ApiResponseError(body["code"], error_msg)
+                    if body.get("code") is not None:
+                        raise ApiResponseError(body.get("code"), error_msg)
                     raise HttpError(response.status, error_msg)
-                if not body["success"]:
+                if not body.get("success"):
                     logger.debug(body)
-                    raise ApiResponseError(body["code"], body["message"])
-        return body["data"]
+                    raise ApiResponseError(body.get("code"), body.get("message"))
+        return body.get("data")

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -561,6 +561,10 @@ class EcosMockServer:
         await asyncio.sleep(1.0)
         return self._success_response({"slept": True})
 
+    async def handle_malformed(self, request: web.Request) -> web.Response:
+        """Return HTTP 200 with valid JSON that lacks the expected envelope keys."""
+        return web.json_response({"foo": "bar"}, status=200)
+
     async def catch_all(self, request: web.Request) -> web.Response:
         """Catch all endpoint."""
         # if request.path starts with /api/client/ then
@@ -616,6 +620,7 @@ class EcosMockServer:
                     self.handle_get_fault_events,
                 ),
                 web.get("/slow", self.handle_slow),
+                web.get("/malformed", self.handle_malformed),
                 web.route("*", "/+{path:.*}", self.catch_all),
             ]
         )

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,26 @@
+"""Unit tests for robust handling of malformed API responses."""
+
+import pytest
+
+import ecactus
+from ecactus.exceptions import ApiResponseError, EcosApiError
+
+
+async def test_async_malformed_response_raises_library_error(mock_server):
+    """Valid JSON without the expected envelope keys must raise a library error.
+
+    Previously the code indexed ``body["success"]`` / ``body["code"]`` directly,
+    so a response missing those keys raised a bare ``KeyError`` that callers
+    could not catch via the documented ``EcosApiError`` hierarchy.
+    """
+    client = ecactus.AsyncEcos(url=mock_server.url)
+    with pytest.raises(EcosApiError) as exc_info:
+        await client._async_get("/malformed")  # noqa: SLF001
+    assert isinstance(exc_info.value, ApiResponseError)
+
+
+def test_sync_malformed_response_raises_library_error(mock_server):
+    """Same guarantee for the synchronous transport."""
+    client = ecactus.Ecos(url=mock_server.url)
+    with pytest.raises(EcosApiError):
+        client._get("/malformed")  # noqa: SLF001


### PR DESCRIPTION
## Problem

The response handlers index the JSON envelope directly (`body["code"]`, `body["success"]`, `body["data"]`, `body["message"]`). A response that is valid JSON but missing one of these keys — e.g. a proxy/error page or an API contract change — raises a bare `KeyError`, which callers cannot catch through the documented `EcosApiError` hierarchy.

## Change

Use `body.get(...)` throughout, so a malformed envelope surfaces as an `ApiResponseError` (an `EcosApiError`) instead of a `KeyError`.

## Tests

Adds a `/malformed` route to the mock server (valid JSON, no envelope keys) and `tests/test_error_handling.py` asserting an `EcosApiError`/`ApiResponseError` is raised on both the sync and async transports.

Verified in a clean `.[dev]` environment (matching CI): `ruff`, `mypy`, `pytest` and `scripts/unasync.py --check` all pass.
