### PR TITLE
fix: allow small negative power readings in PowerMetrics

### DIFF
--- a/src/ecactus/model.py
+++ b/src/ecactus/model.py
@@ -161,11 +161,16 @@ class PowerMetrics(BaseModel):
     """
 
     timestamp: datetime = Field(default_factory=datetime.now)
-    solar: Annotated[float | None, Field(strict=True, ge=0, alias="solarPower")]
+    # No ge=0 constraint: the live API legitimately returns small negative
+    # readings (measurement noise around zero, e.g. homePower=-2.0). Rejecting
+    # them raised a ValidationError that discarded the entire surrounding
+    # payload (a whole DeviceInsight / PowerTimeSeries), so a single noisy field
+    # lost otherwise-valid data. strict=True is kept to avoid silent coercion.
+    solar: Annotated[float | None, Field(strict=True, alias="solarPower")]
     grid: float | None = Field(alias="gridPower")
     battery: float | None = Field(alias="batteryPower")
     meter: float | None = Field(alias="meterPower")
-    home: Annotated[float | None, Field(strict=True, ge=0, alias="homePower")]
+    home: Annotated[float | None, Field(strict=True, alias="homePower")]
     eps: float | None = Field(alias="epsPower")
     charge: float | None = Field(alias="chargePower", default=None)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -7,6 +7,7 @@ import pytest
 from ecactus.model import (
     ConsumptionMetrics,
     ConsumptionTimeSeries,
+    DeviceInsight,
     EnergyHistory,
     Event,
     EventType,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,7 +2,9 @@
 
 from datetime import datetime
 
-from ecactus.model import ConsumptionMetrics, PowerMetrics
+import pytest
+
+from ecactus.model import ConsumptionMetrics, DeviceInsight, PowerMetrics
 
 
 def test_power_metrics_timestamp_uses_default_factory():
@@ -38,3 +40,67 @@ def test_consumption_metrics_timestamp_uses_default_factory():
         selfPoweredDps=0,
     )
     assert metric.timestamp >= before
+
+
+def test_power_metrics_accepts_small_negative_values():
+    """The live API returns small negative power readings (noise around zero).
+
+    These must not raise: a single out-of-range field previously aborted the
+    whole nested parse (DeviceInsight / PowerTimeSeries) and discarded valid
+    data alongside it.
+    """
+    metric = PowerMetrics(
+        solarPower=0,
+        gridPower=0,
+        batteryPower=0,
+        meterPower=0,
+        homePower=-2.0,
+        epsPower=0,
+    )
+    assert metric.home == -2.0
+    assert metric.solar == 0
+
+
+def test_power_metrics_still_rejects_wrong_type():
+    """strict=True is kept: a non-numeric value is still rejected."""
+    with pytest.raises(ValueError):  # noqa: PT011
+        PowerMetrics(
+            solarPower="not-a-number",
+            gridPower=0,
+            batteryPower=0,
+            meterPower=0,
+            homePower=0,
+            epsPower=0,
+        )
+
+
+def test_device_insight_survives_negative_realtime_value():
+    """A negative realtime homePower must not break the surrounding DeviceInsight parse."""
+    insight = DeviceInsight.model_validate(
+        {
+            "selfPowered": 42,
+            "deviceRealtimeDto": {
+                "solarPowerDps": {"1740783600": 0.0},
+                "batteryPowerDps": {"1740783600": 0.0},
+                "gridPowerDps": {"1740783600": 0.0},
+                "meterPowerDps": {"1740783600": 0.0},
+                "homePowerDps": {"1740783600": -2.0},
+                "epsPowerDps": {"1740783600": 0.0},
+            },
+            "deviceStatisticsDto": {
+                "consumptionEnergy": 12.3,
+                "fromBattery": 1.0,
+                "toBattery": 2.0,
+                "fromGrid": 3.0,
+                "toGrid": 4.0,
+                "fromSolar": 5.0,
+                "eps": 0.0,
+            },
+            "insightConsumptionDataDto": None,
+        }
+    )
+    assert insight.self_powered == 42
+    assert insight.energy_statistics is not None
+    assert insight.energy_statistics.consumption == 12.3
+    assert insight.power_timeseries is not None
+    assert insight.power_timeseries.metrics[0].home == -2.0


### PR DESCRIPTION
## Problem

`PowerMetrics.solar` and `PowerMetrics.home` carry a `ge=0` constraint. In practice the live ECOS API occasionally returns small **negative** power readings — e.g. `homePower=-2.0` — which are just measurement noise around zero.

Because these fields are nested inside `DeviceInsight.deviceRealtimeDto` (a `PowerTimeSeries` of `PowerMetrics`), a single such value raises a `ValidationError` that aborts the parse of the **entire** `DeviceInsight` — including the `deviceStatisticsDto` (energy statistics) in the same response, which is perfectly valid. So one noisy field discards a whole otherwise-good payload.

## Change

Drop the `ge=0` constraint on `solar` and `home`. `strict=True` is kept, so non-numeric values are still rejected — only the value-range check is relaxed, not the type check.

## Tests

- `test_power_metrics_accepts_small_negative_values` — a negative `homePower` no longer raises.
- `test_power_metrics_still_rejects_wrong_type` — `strict=True` still rejects a non-numeric value.
- `test_device_insight_survives_negative_realtime_value` — a negative realtime reading no longer breaks the surrounding `DeviceInsight` parse (its energy statistics are still returned).

Verified in a clean `.[dev]` environment matching CI: `ruff`, `mypy`, `pytest`, `scripts/unasync.py --check` all pass.

## Open question

I went with the minimal change (just remove `ge=0`). If you'd rather preserve the "never negative" intent, an alternative is to clamp small negatives to `0` via a validator instead — happy to switch to that if you prefer.
